### PR TITLE
As a user, I want to be able to set a default string, so that a predefined message can be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ This extension is an extension made to formalize git commit messages. By using a
 
 By example: When you want to specify a **scope** in your commits, you can create a variable named scope in th e template like this `{scope}`
 
+## Default values
+
+### Default select
+
 If you want to specify which data you want in this scope variable, you can specify it with the variable settings
 
 ```json
@@ -28,9 +32,19 @@ If you want to specify which data you want in this scope variable, you can speci
 }
 ```
 
-I show you more on the #Settings part
+### Default string
 
-<zz>toto</zz>
+by submitting a string variable instead of an array, this will open the prompt with the default value you put
+
+```json
+{
+  "message": "[skip ci]"
+}
+```
+
+will prefill the prompt with this value.
+
+I show you more on the #Settings part
 
 ## How to use it ?
 

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -3,7 +3,7 @@ import { EXTENSION_NAME } from './const';
 
 export const QUICKPICKITEMSKEKE: Array<IQuickPickSettings> = [
   {
-    label: '✨feature',
+    label: '✨ feature',
     detail: 'Select when creating new things',
   },
   {

--- a/src/scripts/run.ts
+++ b/src/scripts/run.ts
@@ -25,12 +25,7 @@ export const execute = async (repo: Repository) => {
       key: v,
       value: '',
     };
-    if (!variableValue) {
-      result.value = await useQuickText({
-        ignoreFocusOut: true,
-        placeHolder: `Please type the value for <${v}>`,
-      });
-    } else {
+    if (Array.isArray(variableValue)) {
       const choices: IQuickPickSettings[] = parseVariable(repo, v);
       result.value = await useQuickPick(
         {
@@ -42,6 +37,12 @@ export const execute = async (repo: Repository) => {
           detail: c.detail ?? '',
         }))
       );
+    } else {
+      result.value = await useQuickText({
+        value: variableValue,
+        ignoreFocusOut: true,
+        placeHolder: `Please type the value for <${v}>`,
+      });
     }
     variablesReplacement.push(result);
   }


### PR DESCRIPTION
Small PR to allow users to be able to set default strings for variables. This also contains a bug fix.
Also, there was a missing space in the default options in constants

WHO
As a user, 

WHAT
I want to be able to set a default string for a variable

WHY ?
* To be able to have predefined messages if I so desire
* To fix a bug because today if a string is put insteadf of an array, the if condition triggers as an array and will therefore crash the message