### PR TITLE
Trim template result before setting git commit message, refs #29

### DIFF
--- a/src/utils/template.ts
+++ b/src/utils/template.ts
@@ -22,5 +22,5 @@ export const templateSerialize = (
     const e = data[i];
     newTemplate = newTemplate.replace(`{${e.key}}`, e.value);
   }
-  return newTemplate;
+  return newTemplate.trim();
 };


### PR DESCRIPTION
As described in #29 there are cases where additional empty lines at the end of the message can occur. This patch strips them from the template result before setting it as the git commit message.