### PR TITLE
🐞 fix (#39): get right repo to receive message

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,8 +19,8 @@ export function activate(context: ExtensionContext) {
     'vscodeGitCommit.setMessage',
     (params) => {
       commands.executeCommand('workbench.view.scm');
-      const repoUri =
-        params?._quickDiffProvider?.repository?.repositoryRoot || undefined;
+      const repoUri = params.rootUri.toString();
+        // params?._quickDiffProvider?.repository?.repositoryRoot || undefined;
       let repo: Repository | false = getRepo(repoUri);
       if (!!repo) {
         setTimeout(async () => {


### PR DESCRIPTION
#### TL; DR;
fix (#39)

---

When there is more than one repo, the commit text is set to the module whose name is the furthest in alphabetical order, as described by [this comment](https://github.com/rioukkevin/vscode-git-commit/issues/39#issuecomment-1653295990) from [YorickColeu](https://github.com/YorickColeu).

This seems to be caused by the result of function [`getRepo`](https://github.com/rioukkevin/vscode-git-commit/blob/328a0d02fb79ab8cdc745e35e20c025eddbc1ef8/src/utils/git.ts#L11-L26) which returns the first item in the list of repositories if `repo` is `undefined`.

https://github.com/rioukkevin/vscode-git-commit/blob/328a0d02fb79ab8cdc745e35e20c025eddbc1ef8/src/utils/git.ts#L20-L25

But `repo` seems to be always `undefined` because `repoUri` is passed wrong to the function and never found.

This simple commit tries to fix that, passing the correct `repoUri` value in the `index.ts` file with the expression below:

```typescript
const repoUri = params.rootUri.toString();
```