### PR TITLE
Get "command" `Git prefix emote` back to work

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ export function activate(context: ExtensionContext) {
     'vscodeGitCommit.setMessage',
     (params) => {
       commands.executeCommand('workbench.view.scm');
-      const repoUri = params.rootUri.toString();
+      const repoUri = params?.rootUri?.toString() || undefined;
         // params?._quickDiffProvider?.repository?.repositoryRoot || undefined;
       let repo: Repository | false = getRepo(repoUri);
       if (!!repo) {


### PR DESCRIPTION
Fix #43

---

After merge PR #41, the command `"Git prefix emote"` (or keybinding <kbd>ctrl</kbd>+<kbd>alt</kbd>+<kbd>enter</kbd>) stopped working.
It results in an error.

The first commit of this PR fix that.

The second commit of this PR makes the `command` "try" to get the right repo to receive the message by checking the **active opened document in the workspace**. It fixes #39 somehow in those cases (command from the command pallet or from 
 keybinding). Fell free to revert it if it is not good.

When there is no active opened document and the command is executed by these ways (from the command pallet or from 
 keybinding), then, the extension behaves like reported in #39.